### PR TITLE
feat: improve logo legibility

### DIFF
--- a/app/components/TeamInfo/index.tsx
+++ b/app/components/TeamInfo/index.tsx
@@ -20,7 +20,7 @@ function TeamInfo({ team }: TeamInfoProps) {
   return (
     <div className="flex w-1/4 flex-col items-center text-center">
       <Image
-        className="drop-shadow-[0_0_6px_rgba(255,255,255,0.6)]"
+        className="drop-shadow-smoth"
         src={logo}
         width={48}
         height={48}

--- a/app/components/TeamInfo/index.tsx
+++ b/app/components/TeamInfo/index.tsx
@@ -19,7 +19,13 @@ function TeamInfo({ team }: TeamInfoProps) {
 
   return (
     <div className="flex w-1/4 flex-col items-center text-center">
-      <Image src={logo} width={48} height={48} alt={team.teamName} />
+      <Image
+        className="drop-shadow-[0_0_6px_rgba(255,255,255,0.6)]"
+        src={logo}
+        width={48}
+        height={48}
+        alt={team.teamName}
+      />
       <p className="mt-1 whitespace-nowrap text-sm font-semibold">{teamName}</p>
       {hasRecord && (
         <p className="text-xs text-gray-400">{`${team.wins}-${team.losses}`}</p>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -32,6 +32,9 @@ const config: Config = {
       gridTemplateColumns: {
         "auto-fill": "repeat(auto-fill, minmax(320px, 1fr))",
       },
+      dropShadow: {
+        smoth: '0 0 1px rgba(255,255,255,0.6)'
+      }
     },
   },
   plugins: [],


### PR DESCRIPTION
#30 
It apply this smoth shadow in all logos. That which has not a good contrast between background will, now, appear a little bit more, in example of Utah Jazz one.

**Before:**
![image](https://github.com/user-attachments/assets/7ec8d10f-3277-483e-b6bd-60d56889e12f)

**After:**
![image](https://github.com/user-attachments/assets/cb63016a-14a2-4fbf-875e-f754be695943)